### PR TITLE
changes to make spec work and to document (start)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ git clone git@github.com:pariyatti/kosa-crux.git
 cd kosa-crux
 lein deps
 lein scss :development auto
-lein run # Or `lein repl` for interactive programming
+lein run # Or `lein repl` for interactive programming: run `(start)` to start the server in that case
 ```
 
 ## License and Copyright

--- a/src/kosa_crux/entity/pali_word/spec.clj
+++ b/src/kosa_crux/entity/pali_word/spec.clj
@@ -2,31 +2,31 @@
   (:require [clojure.string]
             [clojure.spec.alpha :as s]))
 
-(s/def :entity/truthy-string (s/and string? #(or (= "true" %)
+(s/def ::truthy-string (s/and string? #(or (= "true" %)
                                                  (= "false" %))))
-(s/def :entity/truthy-value boolean?)
+(s/def ::truthy-value boolean?)
 
-(s/def :pali-word/published-at inst?)
-(s/def :pali-word/bookmarkable (s/or :entity/truthy-value :entity/truthy-string))
-(s/def :pali-word/shareable (s/or :entity/truthy-value :entity/truthy-string))
-(s/def :pali-word/card-type (s/and string? #(= "pali_word" %)))
-(s/def :pali-word/pali (s/and string? #(-> % clojure.string/blank? not)))
-(s/def :pali-word/id uuid?)
-(s/def :pali-word/header
+(s/def ::published-at inst?)
+(s/def ::bookmarkable (s/or :entity/truthy-value :entity/truthy-string))
+(s/def ::shareable (s/or :entity/truthy-value :entity/truthy-string))
+(s/def ::card-type (s/and string? #(= "pali_word" %)))
+(s/def ::pali (s/and string? #(-> % clojure.string/blank? not)))
+(s/def ::id uuid?)
+(s/def ::header
   (s/and string? #(-> % clojure.string/blank? not)))
 
-(s/def :pali-word.audio/url (s/and string? #(-> % clojure.string/blank? not)))
-(s/def :pali-word/audio (s/keys :req-un [:pali-word.audio/url]))
+(s/def ::url (s/and string? #(-> % clojure.string/blank? not)))
+(s/def ::audio (s/keys :req-un [:pali-word.audio/url]))
 
-(s/def :translations/language (s/and string? #(contains? #{"hi" "en"} %)))
-(s/def :translations/translation (s/and string? #(-> % clojure.string/blank? not)))
-(s/def :translations/id uuid?)
-(s/def :pali-word/translations
+(s/def ::language (s/and string? #(contains? #{"hi" "en"} %)))
+(s/def ::translation (s/and string? #(-> % clojure.string/blank? not)))
+(s/def ::id uuid?)
+(s/def ::translations
   (s/coll-of (s/keys :req-un [:translations/id
                               :translations/translation
                               :translations/language])))
 
-(s/def :entity/pali-word
+(s/def ::pali-word
   (s/keys :req-un [:pali-word/id
                    :pali-word/header
                    :pali-word/bookmarkable
@@ -37,8 +37,6 @@
                    :pali-word/audio
                    :pali-word/translations]))
 
-(s/def :entity/pali-word-request
-  (s/keys :req-un [:pali-word/header
-                   :pali-word/bookmarkable
-                   :pali-word/shareable
-                   :pali-word/pali]))
+(s/def ::pali-word-request
+  (s/keys :req-un [:pali-word/header :pali-word/pali]
+          :opt [:pali-word/bookmarkable :pali-word/shareable]))

--- a/src/kosa_crux/routes.clj
+++ b/src/kosa_crux/routes.clj
@@ -2,6 +2,7 @@
   (:require [ring.util.response :as resp]
             [bidi.ring]
             [kosa-crux.middleware :refer [wrap-spec-validation]]
+            [kosa-crux.entity.pali-word.spec :as spec]
             [kosa-crux.entity.pali-word.handler :as pali-word-handler]))
 
 (defn not-found [_request]
@@ -17,6 +18,7 @@
          ]
         ["publisher/today/pali_word_cards" pali-word-handler/index]
         ["publisher/today/pali_word_card/new" pali-word-handler/new]
-        ["publisher/today/pali_word_card/create" (wrap-spec-validation :entity/pali-word-request pali-word-handler/create)]
+        ["publisher/today/pali_word_card/create" (wrap-spec-validation ::spec/pali-word-request pali-word-handler/create)]
         ["api/v1/today.json" pali-word-handler/list]
+        ["" pali-word-handler/index]
         [true not-found]]])


### PR DESCRIPTION
I made some stylistic changes to the spec integration, maybe this is not what's wanted!  The main change is to make the spec statements namespace qualified, like `::shareable`. I couldn't get it working before when the bookmarkable and sharable boxes were not ticked, so I made those an optional part of the spec.

(An alternative strategy would be how to get Hiccup forms to supply a default value.)